### PR TITLE
feat: build user dashboard with saved project plans (#11)

### DIFF
--- a/src/app/dashboard/[planId]/loading.tsx
+++ b/src/app/dashboard/[planId]/loading.tsx
@@ -1,0 +1,19 @@
+export default function PlanDetailLoading() {
+  return (
+    <div className="flex flex-col gap-6 animate-pulse">
+      <div className="flex items-center gap-2">
+        <div className="h-3 w-20 rounded-full bg-zinc-100" />
+      </div>
+      <div className="h-7 w-1/2 rounded-full bg-zinc-100" />
+      <div className="h-4 w-2/3 rounded-full bg-zinc-100" />
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-xl border border-zinc-100 overflow-hidden">
+            <div className="h-10 bg-zinc-100" />
+            <div className="h-32 bg-white" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/[planId]/not-found.tsx
+++ b/src/app/dashboard/[planId]/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function PlanNotFound() {
+  return (
+    <div className="flex flex-col items-center gap-4 py-16 text-center">
+      <p className="text-sm font-medium text-zinc-700">Plan not found</p>
+      <p className="text-sm text-zinc-500">
+        This plan may have been deleted or doesn&apos;t belong to your account.
+      </p>
+      <Link
+        href="/dashboard"
+        className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 transition-colors"
+      >
+        Back to dashboard
+      </Link>
+    </div>
+  );
+}

--- a/src/app/dashboard/[planId]/page.tsx
+++ b/src/app/dashboard/[planId]/page.tsx
@@ -1,0 +1,79 @@
+export const dynamic = 'force-dynamic';
+
+import { notFound, redirect } from 'next/navigation';
+import Link from 'next/link';
+import { createServerClient } from '@/lib/supabase/server';
+import { getProjectPlanById } from '@/lib/supabase/queries/get-project-plans';
+import { planIdSchema } from '@/lib/validators/plan-id';
+import { ConfigFileDisplay } from '@/components/dashboard/ConfigFileDisplay';
+import type { GenerateConfigResult } from '@/types/generators';
+
+interface PlanDetailPageProps {
+  params: Promise<{ planId: string }>;
+}
+
+
+function parseConfigData(raw: Record<string, unknown>): GenerateConfigResult | null {
+  if (!raw || typeof raw !== 'object') return null;
+  if (!Array.isArray(raw.configs)) return null;
+  return raw as unknown as GenerateConfigResult;
+}
+
+export default async function PlanDetailPage({ params }: PlanDetailPageProps) {
+  const { planId } = await params;
+
+  const parsed = planIdSchema.safeParse(planId);
+  if (!parsed.success) notFound();
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect('/sign-in');
+
+  const plan = await getProjectPlanById(parsed.data, user.id);
+  if (!plan) notFound();
+
+  const configResult = parseConfigData(plan.config_data);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-2 text-xs text-zinc-400">
+        <Link href="/dashboard" className="hover:text-zinc-700 transition-colors">
+          Dashboard
+        </Link>
+        <span aria-hidden="true">/</span>
+        <span className="text-zinc-600">{plan.name}</span>
+      </div>
+
+      <div>
+        <h1 className="text-xl font-semibold text-zinc-900">{plan.name}</h1>
+        {plan.description && (
+          <p className="mt-1 text-sm text-zinc-500">{plan.description}</p>
+        )}
+        <p className="mt-1 text-xs text-zinc-400">
+          Created{' '}
+          {new Date(plan.created_at).toLocaleDateString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+          })}
+        </p>
+      </div>
+
+      {configResult ? (
+        <div className="flex flex-col gap-4">
+          <h2 className="text-sm font-semibold text-zinc-700">Generated config files</h2>
+          {configResult.configs.map((config) => (
+            <ConfigFileDisplay key={config.format} config={config} />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-8 text-center">
+          <p className="text-sm text-zinc-500">Config data is unavailable for this plan.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/[planId]/page.tsx
+++ b/src/app/dashboard/[planId]/page.tsx
@@ -5,8 +5,21 @@ import Link from 'next/link';
 import { createServerClient } from '@/lib/supabase/server';
 import { getProjectPlanById } from '@/lib/supabase/queries/get-project-plans';
 import { planIdSchema } from '@/lib/validators/plan-id';
+import { z } from 'zod';
 import { ConfigFileDisplay } from '@/components/dashboard/ConfigFileDisplay';
 import type { GenerateConfigResult } from '@/types/generators';
+import { CONFIG_FORMAT } from '@/types/generators';
+
+const generatedConfigSchema = z.object({
+  format: z.enum([CONFIG_FORMAT.claude, CONFIG_FORMAT.gemini, CONFIG_FORMAT.copilot]),
+  filename: z.string().min(1).max(200),
+  content: z.string().max(500_000),
+});
+
+const configResultSchema = z.object({
+  projectName: z.string().min(1).max(200),
+  configs: z.array(generatedConfigSchema),
+});
 
 interface PlanDetailPageProps {
   params: Promise<{ planId: string }>;
@@ -14,9 +27,8 @@ interface PlanDetailPageProps {
 
 
 function parseConfigData(raw: Record<string, unknown>): GenerateConfigResult | null {
-  if (!raw || typeof raw !== 'object') return null;
-  if (!Array.isArray(raw.configs)) return null;
-  return raw as unknown as GenerateConfigResult;
+  const result = configResultSchema.safeParse(raw);
+  return result.success ? result.data : null;
 }
 
 export default async function PlanDetailPage({ params }: PlanDetailPageProps) {

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -1,0 +1,31 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createServerClient } from '@/lib/supabase/server';
+import { planIdSchema } from '@/lib/validators/plan-id';
+import { deleteProjectPlan } from '@/lib/supabase/queries/get-project-plans';
+import type { ApiResponse } from '@/types/api';
+
+export async function deletePlanAction(
+  planId: string,
+): Promise<ApiResponse<{ deleted: true }>> {
+  const parsed = planIdSchema.safeParse(planId);
+  if (!parsed.success) {
+    return { success: false, error: 'Invalid plan ID' };
+  }
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { success: false, error: 'Unauthorized' };
+
+  const result = await deleteProjectPlan(parsed.data, user.id);
+  if (!result.success) {
+    return { success: false, error: result.error ?? 'Failed to delete plan' };
+  }
+
+  revalidatePath('/dashboard');
+  return { success: true, data: { deleted: true } };
+}

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-16 text-center">
+      <p className="text-sm text-zinc-500">{error.message || 'Something went wrong loading your dashboard.'}</p>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,9 @@
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex-1 flex flex-col">
+      <div className="mx-auto w-full max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,19 @@
+export default function DashboardLoading() {
+  return (
+    <div className="flex flex-col gap-6 animate-pulse">
+      <div className="h-6 w-32 rounded-full bg-zinc-100" />
+      <div className="h-16 rounded-xl bg-zinc-100" />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-3 rounded-xl border border-zinc-100 p-5">
+            <div className="h-4 w-3/4 rounded-full bg-zinc-100" />
+            <div className="h-3 w-full rounded-full bg-zinc-100" />
+            <div className="h-3 w-2/3 rounded-full bg-zinc-100" />
+            <div className="mt-2 h-px bg-zinc-100" />
+            <div className="h-3 w-1/4 rounded-full bg-zinc-100" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,44 @@
+export const dynamic = 'force-dynamic';
+
+import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { createServerClient } from '@/lib/supabase/server';
+import { getProjectPlansByUser } from '@/lib/supabase/queries/get-project-plans';
+import { DashboardStats } from '@/components/dashboard/DashboardStats';
+import { PlanCard } from '@/components/dashboard/PlanCard';
+import { EmptyDashboard } from '@/components/dashboard/EmptyDashboard';
+
+export const metadata: Metadata = {
+  title: 'Dashboard — DevPrint',
+  description: 'Your saved project plans and generated config files.',
+};
+
+export default async function DashboardPage() {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect('/sign-in');
+
+  const plans = await getProjectPlansByUser(user.id);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h1 className="text-xl font-semibold text-zinc-900">Your plans</h1>
+
+      {plans.length === 0 ? (
+        <EmptyDashboard />
+      ) : (
+        <>
+          <DashboardStats plans={plans} />
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {plans.map((plan) => (
+              <PlanCard key={plan.id} plan={plan} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/ConfigFileDisplay.tsx
+++ b/src/components/dashboard/ConfigFileDisplay.tsx
@@ -1,0 +1,25 @@
+import type { GeneratedConfig } from '@/types/generators';
+import { CopyConfigButton } from './CopyConfigButton';
+
+export interface ConfigFileDisplayProps {
+  config: GeneratedConfig;
+}
+
+export function ConfigFileDisplay({ config }: ConfigFileDisplayProps) {
+  return (
+    <div className="rounded-xl border border-zinc-200 overflow-hidden">
+      <div className="flex items-center justify-between bg-zinc-50 px-4 py-3 border-b border-zinc-200">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-zinc-700">{config.filename}</span>
+          <span className="rounded-full bg-zinc-200 px-2 py-0.5 text-xs text-zinc-500 capitalize">
+            {config.format}
+          </span>
+        </div>
+        <CopyConfigButton content={config.content} filename={config.filename} />
+      </div>
+      <pre className="overflow-x-auto px-4 py-4 text-xs leading-relaxed text-zinc-700 whitespace-pre-wrap">
+        {config.content}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/dashboard/CopyConfigButton.tsx
+++ b/src/components/dashboard/CopyConfigButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface CopyConfigButtonProps {
+  content: string;
+  filename: string;
+}
+
+export function CopyConfigButton({ content, filename }: CopyConfigButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="text-xs text-zinc-400 hover:text-zinc-700 transition-colors"
+      aria-label={`Copy ${filename} to clipboard`}
+    >
+      {copied ? 'Copied!' : 'Copy'}
+    </button>
+  );
+}

--- a/src/components/dashboard/DashboardStats.tsx
+++ b/src/components/dashboard/DashboardStats.tsx
@@ -1,0 +1,40 @@
+import type { ProjectPlanSummary } from '@/types/dashboard';
+
+export interface DashboardStatsProps {
+  plans: ProjectPlanSummary[];
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function DashboardStats({ plans }: DashboardStatsProps) {
+  const total = plans.length;
+  const mostRecent = plans[0];
+
+  return (
+    <div className="flex items-center gap-6 rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-4">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-2xl font-semibold text-zinc-900">{total}</span>
+        <span className="text-xs text-zinc-500">
+          {total === 1 ? 'saved plan' : 'saved plans'}
+        </span>
+      </div>
+      {mostRecent && (
+        <>
+          <div className="h-8 w-px bg-zinc-200" aria-hidden="true" />
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm font-medium text-zinc-900">{mostRecent.name}</span>
+            <span className="text-xs text-zinc-500">
+              Most recent · {formatDate(mostRecent.created_at)}
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/DeletePlanButton.tsx
+++ b/src/components/dashboard/DeletePlanButton.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { deletePlanAction } from '@/app/dashboard/actions';
+
+export interface DeletePlanButtonProps {
+  planId: string;
+  planName: string;
+}
+
+export function DeletePlanButton({ planId, planName }: DeletePlanButtonProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDeleteClick(e: React.MouseEvent) {
+    e.preventDefault();
+    setConfirming(true);
+  }
+
+  function handleCancel(e: React.MouseEvent) {
+    e.preventDefault();
+    setConfirming(false);
+  }
+
+  function handleConfirm(e: React.MouseEvent) {
+    e.preventDefault();
+    startTransition(async () => {
+      await deletePlanAction(planId);
+      setConfirming(false);
+    });
+  }
+
+  if (confirming) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-zinc-500 shrink-0">Delete &ldquo;{planName}&rdquo;?</span>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={isPending}
+          className="rounded px-2 py-1 text-xs font-medium bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50"
+        >
+          {isPending ? 'Deleting…' : 'Delete'}
+        </button>
+        <button
+          type="button"
+          onClick={handleCancel}
+          disabled={isPending}
+          className="rounded px-2 py-1 text-xs font-medium text-zinc-500 hover:text-zinc-900 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleDeleteClick}
+      className="text-xs text-zinc-400 hover:text-red-600 transition-colors"
+      aria-label={`Delete plan ${planName}`}
+    >
+      Delete
+    </button>
+  );
+}

--- a/src/components/dashboard/DeletePlanButton.tsx
+++ b/src/components/dashboard/DeletePlanButton.tsx
@@ -10,24 +10,38 @@ export interface DeletePlanButtonProps {
 
 export function DeletePlanButton({ planId, planName }: DeletePlanButtonProps) {
   const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   function handleDeleteClick(e: React.MouseEvent) {
     e.preventDefault();
+    setError(null);
     setConfirming(true);
   }
 
   function handleCancel(e: React.MouseEvent) {
     e.preventDefault();
     setConfirming(false);
+    setError(null);
   }
 
   function handleConfirm(e: React.MouseEvent) {
     e.preventDefault();
     startTransition(async () => {
-      await deletePlanAction(planId);
+      const result = await deletePlanAction(planId);
+      if (!result.success) {
+        setError(result.error ?? 'Delete failed. Please try again.');
+        setConfirming(false);
+        return;
+      }
       setConfirming(false);
     });
+  }
+
+  if (error) {
+    return (
+      <span className="text-xs text-red-600">{error}</span>
+    );
   }
 
   if (confirming) {

--- a/src/components/dashboard/EmptyDashboard.tsx
+++ b/src/components/dashboard/EmptyDashboard.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+
+export function EmptyDashboard() {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-8 py-16 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100">
+        <svg className="h-6 w-6 text-zinc-400" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-zinc-700">No plans yet</p>
+        <p className="text-sm text-zinc-500">
+          Use the wizard to plan your tech stack and generate config files.
+        </p>
+      </div>
+      <Link
+        href="/wizard"
+        className="mt-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 transition-colors"
+      >
+        Start planning
+      </Link>
+    </div>
+  );
+}

--- a/src/components/dashboard/PlanCard.tsx
+++ b/src/components/dashboard/PlanCard.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import type { ProjectPlanSummary } from '@/types/dashboard';
+import { DeletePlanButton } from './DeletePlanButton';
+
+export interface PlanCardProps {
+  plan: ProjectPlanSummary;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function PlanCard({ plan }: PlanCardProps) {
+  return (
+    <div className="group flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-5 shadow-sm transition-all duration-150 hover:border-zinc-300 hover:shadow-md">
+      <div className="flex items-start justify-between gap-3">
+        <Link
+          href={`/dashboard/${plan.id}`}
+          className="flex-1 min-w-0"
+        >
+          <span className="block text-base font-semibold text-zinc-900 group-hover:text-zinc-700 transition-colors truncate">
+            {plan.name}
+          </span>
+        </Link>
+        <DeletePlanButton planId={plan.id} planName={plan.name} />
+      </div>
+
+      {plan.description && (
+        <p className="text-sm leading-relaxed text-zinc-500 line-clamp-2">{plan.description}</p>
+      )}
+
+      <div className="mt-auto flex items-center justify-between border-t border-zinc-100 pt-3">
+        <span className="text-xs text-zinc-400">{formatDate(plan.created_at)}</span>
+        <Link
+          href={`/dashboard/${plan.id}`}
+          className="text-xs font-medium text-zinc-500 hover:text-zinc-900 transition-colors"
+        >
+          View configs →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -35,6 +35,12 @@ export default async function Header() {
             {user ? (
               <>
                 <Link
+                  href="/dashboard"
+                  className="text-sm text-zinc-600 hover:text-zinc-900 transition-colors"
+                >
+                  Dashboard
+                </Link>
+                <Link
                   href="/wizard"
                   className="text-sm text-zinc-600 hover:text-zinc-900 transition-colors"
                 >

--- a/src/lib/supabase/queries/__tests__/get-project-plans.test.ts
+++ b/src/lib/supabase/queries/__tests__/get-project-plans.test.ts
@@ -1,0 +1,225 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import {
+  getProjectPlansByUser,
+  getProjectPlanById,
+  deleteProjectPlan,
+} from '../get-project-plans';
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from '@/lib/supabase/server';
+
+const MOCK_PLAN_SUMMARY = {
+  id: 'plan-1',
+  name: 'My App',
+  description: 'A great app',
+  created_at: '2026-04-01T00:00:00Z',
+  updated_at: '2026-04-01T00:00:00Z',
+};
+
+const MOCK_PLAN_FULL = {
+  ...MOCK_PLAN_SUMMARY,
+  user_id: 'user-1',
+  selections: { frontend: 'Next.js' },
+  config_data: { projectName: 'My App', configs: [] },
+};
+
+function makeMockChain(resolvedValue: { data: unknown; error: unknown }) {
+  const chain: Record<string, Mock> = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
+    maybeSingle: vi.fn(),
+    delete: vi.fn(),
+  };
+  // Every method returns the same chain object, except terminal ones
+  chain.select.mockReturnValue(chain);
+  chain.eq.mockReturnValue(chain);
+  chain.order.mockReturnValue(chain);
+  chain.delete.mockReturnValue(chain);
+  chain.limit.mockResolvedValue(resolvedValue);
+  chain.maybeSingle.mockResolvedValue(resolvedValue);
+  return chain;
+}
+
+function makeDeleteChain(resolvedValue: { error: unknown }) {
+  const chain: Record<string, Mock> = {
+    delete: vi.fn(),
+    eq: vi.fn(),
+  };
+  chain.delete.mockReturnValue(chain);
+  // Each .eq() call returns the chain; the last one resolves
+  chain.eq.mockReturnValue(chain);
+  // Override: make the chain itself thenable for the last eq
+  (chain as unknown as Promise<unknown>)[Symbol.iterator] = undefined as never;
+  // Use a custom approach: last eq resolves the promise
+  let eqCount = 0;
+  chain.eq.mockImplementation(() => {
+    eqCount++;
+    if (eqCount >= 2) {
+      return Promise.resolve(resolvedValue);
+    }
+    return chain;
+  });
+  return chain;
+}
+
+function mockClient(queryChain: Record<string, Mock>) {
+  (createServerClient as Mock).mockResolvedValue({
+    from: vi.fn().mockReturnValue(queryChain),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── getProjectPlansByUser ─────────────────────────────────────────────────
+
+describe('getProjectPlansByUser', () => {
+  it('returns an array of plan summaries', async () => {
+    const chain = makeMockChain({ data: [MOCK_PLAN_SUMMARY], error: null });
+    mockClient(chain);
+    const result = await getProjectPlansByUser('user-1');
+    expect(result).toEqual([MOCK_PLAN_SUMMARY]);
+  });
+
+  it('returns empty array when user has no plans', async () => {
+    const chain = makeMockChain({ data: [], error: null });
+    mockClient(chain);
+    const result = await getProjectPlansByUser('user-1');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array (does not throw) when Supabase returns an error', async () => {
+    const chain = makeMockChain({ data: null, error: { message: 'DB error' } });
+    mockClient(chain);
+    const result = await getProjectPlansByUser('user-1');
+    expect(result).toEqual([]);
+  });
+
+  it('filters by user_id', async () => {
+    const chain = makeMockChain({ data: [], error: null });
+    mockClient(chain);
+    await getProjectPlansByUser('user-abc');
+    expect(chain.eq).toHaveBeenCalledWith('user_id', 'user-abc');
+  });
+
+  it('orders results by created_at descending', async () => {
+    const chain = makeMockChain({ data: [], error: null });
+    mockClient(chain);
+    await getProjectPlansByUser('user-1');
+    expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('applies a limit of 50', async () => {
+    const chain = makeMockChain({ data: [], error: null });
+    mockClient(chain);
+    await getProjectPlansByUser('user-1');
+    expect(chain.limit).toHaveBeenCalledWith(50);
+  });
+
+  it('selects only summary columns (no selections or config_data)', async () => {
+    const chain = makeMockChain({ data: [], error: null });
+    mockClient(chain);
+    await getProjectPlansByUser('user-1');
+    const selectedCols: string = chain.select.mock.calls[0][0];
+    expect(selectedCols).toContain('id');
+    expect(selectedCols).toContain('name');
+    expect(selectedCols).toContain('description');
+    expect(selectedCols).toContain('created_at');
+    expect(selectedCols).not.toContain('selections');
+    expect(selectedCols).not.toContain('config_data');
+  });
+});
+
+// ─── getProjectPlanById ───────────────────────────────────────────────────
+
+describe('getProjectPlanById', () => {
+  it('returns the plan when it exists and belongs to the user', async () => {
+    const chain = makeMockChain({ data: MOCK_PLAN_FULL, error: null });
+    mockClient(chain);
+    const result = await getProjectPlanById('plan-1', 'user-1');
+    expect(result).toEqual(MOCK_PLAN_FULL);
+  });
+
+  it('returns null when plan does not exist', async () => {
+    const chain = makeMockChain({ data: null, error: null });
+    mockClient(chain);
+    const result = await getProjectPlanById('nonexistent', 'user-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null (does not throw) when Supabase returns an error', async () => {
+    const chain = makeMockChain({ data: null, error: { message: 'not found' } });
+    mockClient(chain);
+    const result = await getProjectPlanById('plan-1', 'user-1');
+    expect(result).toBeNull();
+  });
+
+  it('filters by both plan id and user_id (ownership)', async () => {
+    const chain = makeMockChain({ data: MOCK_PLAN_FULL, error: null });
+    mockClient(chain);
+    await getProjectPlanById('plan-1', 'user-1');
+    const eqCalls = chain.eq.mock.calls;
+    expect(eqCalls).toContainEqual(['id', 'plan-1']);
+    expect(eqCalls).toContainEqual(['user_id', 'user-1']);
+  });
+
+  it('returns full plan including selections and config_data', async () => {
+    const chain = makeMockChain({ data: MOCK_PLAN_FULL, error: null });
+    mockClient(chain);
+    const result = await getProjectPlanById('plan-1', 'user-1');
+    expect(result?.selections).toBeDefined();
+    expect(result?.config_data).toBeDefined();
+  });
+
+  it('includes all columns in select', async () => {
+    const chain = makeMockChain({ data: MOCK_PLAN_FULL, error: null });
+    mockClient(chain);
+    await getProjectPlanById('plan-1', 'user-1');
+    const selectedCols: string = chain.select.mock.calls[0][0];
+    expect(selectedCols).toContain('selections');
+    expect(selectedCols).toContain('config_data');
+    expect(selectedCols).toContain('user_id');
+  });
+});
+
+// ─── deleteProjectPlan ────────────────────────────────────────────────────
+
+describe('deleteProjectPlan', () => {
+  it('returns success: true when deletion succeeds', async () => {
+    const chain = makeDeleteChain({ error: null });
+    mockClient(chain);
+    const result = await deleteProjectPlan('plan-1', 'user-1');
+    expect(result).toEqual({ success: true });
+  });
+
+  it('returns success: false with error message on Supabase error', async () => {
+    const chain = makeDeleteChain({ error: { message: 'delete failed' } });
+    mockClient(chain);
+    const result = await deleteProjectPlan('plan-1', 'user-1');
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('does not throw on error', async () => {
+    const chain = makeDeleteChain({ error: { message: 'db error' } });
+    mockClient(chain);
+    await expect(deleteProjectPlan('plan-1', 'user-1')).resolves.not.toThrow();
+  });
+
+  it('filters by both plan id and user_id', async () => {
+    const chain = makeDeleteChain({ error: null });
+    mockClient(chain);
+    await deleteProjectPlan('plan-1', 'user-1');
+    const eqCalls = chain.eq.mock.calls;
+    expect(eqCalls).toContainEqual(['id', 'plan-1']);
+    expect(eqCalls).toContainEqual(['user_id', 'user-1']);
+  });
+});

--- a/src/lib/supabase/queries/__tests__/get-project-plans.test.ts
+++ b/src/lib/supabase/queries/__tests__/get-project-plans.test.ts
@@ -47,21 +47,15 @@ function makeMockChain(resolvedValue: { data: unknown; error: unknown }) {
   return chain;
 }
 
-function makeDeleteChain(resolvedValue: { error: unknown }) {
+function makeDeleteChain(resolvedValue: { data: unknown; error: unknown }) {
   const chain: Record<string, Mock> = {
     delete: vi.fn(),
     eq: vi.fn(),
+    select: vi.fn(),
   };
   chain.delete.mockReturnValue(chain);
-  // Each .eq() call returns the chain; after two calls the chain resolves
-  let eqCount = 0;
-  chain.eq.mockImplementation(() => {
-    eqCount++;
-    if (eqCount >= 2) {
-      return Promise.resolve(resolvedValue);
-    }
-    return chain;
-  });
+  chain.eq.mockReturnValue(chain);
+  chain.select.mockResolvedValue(resolvedValue);
   return chain;
 }
 
@@ -190,14 +184,22 @@ describe('getProjectPlanById', () => {
 
 describe('deleteProjectPlan', () => {
   it('returns success: true when deletion succeeds', async () => {
-    const chain = makeDeleteChain({ error: null });
+    const chain = makeDeleteChain({ data: [{ id: 'plan-1' }], error: null });
     mockClient(chain);
     const result = await deleteProjectPlan('plan-1', 'user-1');
     expect(result).toEqual({ success: true });
   });
 
   it('returns success: false with error message on Supabase error', async () => {
-    const chain = makeDeleteChain({ error: { message: 'delete failed' } });
+    const chain = makeDeleteChain({ data: null, error: { message: 'delete failed' } });
+    mockClient(chain);
+    const result = await deleteProjectPlan('plan-1', 'user-1');
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('returns success: false when no rows were deleted (plan not found)', async () => {
+    const chain = makeDeleteChain({ data: [], error: null });
     mockClient(chain);
     const result = await deleteProjectPlan('plan-1', 'user-1');
     expect(result.success).toBe(false);
@@ -205,13 +207,13 @@ describe('deleteProjectPlan', () => {
   });
 
   it('does not throw on error', async () => {
-    const chain = makeDeleteChain({ error: { message: 'db error' } });
+    const chain = makeDeleteChain({ data: null, error: { message: 'db error' } });
     mockClient(chain);
     await expect(deleteProjectPlan('plan-1', 'user-1')).resolves.not.toThrow();
   });
 
   it('filters by both plan id and user_id', async () => {
-    const chain = makeDeleteChain({ error: null });
+    const chain = makeDeleteChain({ data: [{ id: 'plan-1' }], error: null });
     mockClient(chain);
     await deleteProjectPlan('plan-1', 'user-1');
     const eqCalls = chain.eq.mock.calls;

--- a/src/lib/supabase/queries/__tests__/get-project-plans.test.ts
+++ b/src/lib/supabase/queries/__tests__/get-project-plans.test.ts
@@ -53,11 +53,7 @@ function makeDeleteChain(resolvedValue: { error: unknown }) {
     eq: vi.fn(),
   };
   chain.delete.mockReturnValue(chain);
-  // Each .eq() call returns the chain; the last one resolves
-  chain.eq.mockReturnValue(chain);
-  // Override: make the chain itself thenable for the last eq
-  (chain as unknown as Promise<unknown>)[Symbol.iterator] = undefined as never;
-  // Use a custom approach: last eq resolves the promise
+  // Each .eq() call returns the chain; after two calls the chain resolves
   let eqCount = 0;
   chain.eq.mockImplementation(() => {
     eqCount++;

--- a/src/lib/supabase/queries/get-project-plans.ts
+++ b/src/lib/supabase/queries/get-project-plans.ts
@@ -1,0 +1,62 @@
+import { createServerClient } from '@/lib/supabase/server';
+import type { ProjectPlan } from '@/types/database';
+import type { ProjectPlanSummary } from '@/types/dashboard';
+
+export async function getProjectPlansByUser(userId: string): Promise<ProjectPlanSummary[]> {
+  const supabase = await createServerClient();
+
+  const { data, error } = await supabase
+    .from('project_plans')
+    .select('id, name, description, created_at, updated_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    console.error('Failed to fetch project plans:', error);
+    return [];
+  }
+
+  return data ?? [];
+}
+
+export async function getProjectPlanById(
+  planId: string,
+  userId: string,
+): Promise<ProjectPlan | null> {
+  const supabase = await createServerClient();
+
+  const { data, error } = await supabase
+    .from('project_plans')
+    .select('id, user_id, name, description, selections, config_data, created_at, updated_at')
+    .eq('id', planId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Failed to fetch project plan:', error);
+    return null;
+  }
+
+  return data ?? null;
+}
+
+export async function deleteProjectPlan(
+  planId: string,
+  userId: string,
+): Promise<{ success: boolean; error?: string }> {
+  const supabase = await createServerClient();
+
+  const { error } = await supabase
+    .from('project_plans')
+    .delete()
+    .eq('id', planId)
+    .eq('user_id', userId);
+
+  if (error) {
+    console.error('Failed to delete project plan:', error);
+    return { success: false, error: 'Failed to delete plan. Please try again.' };
+  }
+
+  return { success: true };
+}

--- a/src/lib/supabase/queries/get-project-plans.ts
+++ b/src/lib/supabase/queries/get-project-plans.ts
@@ -47,15 +47,20 @@ export async function deleteProjectPlan(
 ): Promise<{ success: boolean; error?: string }> {
   const supabase = await createServerClient();
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('project_plans')
     .delete()
     .eq('id', planId)
-    .eq('user_id', userId);
+    .eq('user_id', userId)
+    .select('id');
 
   if (error) {
     console.error('Failed to delete project plan:', error);
     return { success: false, error: 'Failed to delete plan. Please try again.' };
+  }
+
+  if (!data || data.length === 0) {
+    return { success: false, error: 'Plan not found or already deleted.' };
   }
 
   return { success: true };

--- a/src/lib/validators/__tests__/plan-id.test.ts
+++ b/src/lib/validators/__tests__/plan-id.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { planIdSchema } from '../plan-id';
+
+describe('planIdSchema', () => {
+  it('accepts a valid UUID v4', () => {
+    const result = planIdSchema.safeParse('550e8400-e29b-41d4-a716-446655440000');
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a Supabase-generated UUID format', () => {
+    const result = planIdSchema.safeParse('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty string', () => {
+    const result = planIdSchema.safeParse('');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a plain string that is not a UUID', () => {
+    const result = planIdSchema.safeParse('not-a-uuid');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects undefined', () => {
+    const result = planIdSchema.safeParse(undefined);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a number', () => {
+    const result = planIdSchema.safeParse(12345);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a UUID with wrong segment lengths', () => {
+    const result = planIdSchema.safeParse('550e8400-e29b-41d4-a716');
+    expect(result.success).toBe(false);
+  });
+
+  it('returns the validated string on success', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const result = planIdSchema.safeParse(uuid);
+    if (result.success) {
+      expect(result.data).toBe(uuid);
+    }
+  });
+});

--- a/src/lib/validators/plan-id.ts
+++ b/src/lib/validators/plan-id.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const planIdSchema = z.string().uuid('Invalid plan ID');

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,13 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!supabaseUrl || !supabaseAnonKey) {
+    const { pathname } = request.nextUrl;
+    const isProtected = PROTECTED_PATHS.some((path) => pathname.startsWith(path));
+    if (isProtected) {
+      const signInUrl = request.nextUrl.clone();
+      signInUrl.pathname = '/sign-in';
+      return NextResponse.redirect(signInUrl);
+    }
     return response;
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
-const PROTECTED_PATHS = ['/wizard', '/admin', '/contributor'];
+const PROTECTED_PATHS = ['/wizard', '/admin', '/contributor', '/dashboard'];
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   let response = NextResponse.next({ request });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,3 @@
+export type ApiResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; code?: string };

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,6 @@
+import type { ProjectPlan } from './database';
+
+export type ProjectPlanSummary = Pick<
+  ProjectPlan,
+  'id' | 'name' | 'description' | 'created_at' | 'updated_at'
+>;


### PR DESCRIPTION
## Summary

- Adds a protected `/dashboard` route listing the authenticated user's saved project plans with quick stats (total count, most recent plan name + date)
- Empty state with a "Start planning" CTA to `/wizard`
- Each plan card links to `/dashboard/[planId]` which shows all three generated config files (CLAUDE.md, GEMINI.md, copilot-instructions.md) with copy-to-clipboard
- Delete plans with an inline confirmation dialog and error feedback
- Dashboard link added to the Header for authenticated users

## What's in this PR

**Pure lib (TDD, red-green-refactor):**
- `src/lib/supabase/queries/get-project-plans.ts` — `getProjectPlansByUser`, `getProjectPlanById`, `deleteProjectPlan`
- `src/lib/validators/plan-id.ts` — Zod UUID validator
- 26 unit tests, 100% coverage on both modules

**UI components:**
- `DeletePlanButton` — inline confirm/cancel/error state (client)
- `PlanCard` — plan card with link + delete (server)
- `DashboardStats` — total + most recent, derived from fetched list (server)
- `EmptyDashboard` — empty state with wizard CTA (server)
- `CopyConfigButton` — clipboard copy with "Copied!" feedback (client)
- `ConfigFileDisplay` — config file pre block + copy button (server)

**Pages & action:**
- `src/app/dashboard/` — layout, page, loading, error
- `src/app/dashboard/[planId]/` — detail page, loading, not-found
- `src/app/dashboard/actions.ts` — `deletePlanAction` with Zod + auth + ownership check

**Security hardening (from security review):**
- Middleware now fails **closed** on missing Supabase env vars (redirects protected paths to /sign-in)
- `config_data` fully validated with Zod schema before rendering — no `as unknown as` casts
- Delete query uses `.select('id')` to confirm row was actually deleted
- Delete button surfaces server action errors rather than silently swallowing them
- `planId` validated as UUID before any query

## Test plan

- [ ] `npm run test` — 143 tests pass
- [ ] `npm run typecheck` — no errors
- [ ] `npm run build` — `/dashboard` and `/dashboard/[planId]` in route table
- [ ] Unauthenticated visit to `/dashboard` → redirect to `/sign-in`
- [ ] Authenticated user with no plans → empty state with "Start planning" button
- [ ] Authenticated user with plans → stats bar + plan cards
- [ ] Click a plan card → detail page with 3 config files
- [ ] Click "Copy" on a config file → clipboard filled, button shows "Copied!"
- [ ] Click "Delete" on a plan card → inline "Are you sure?" appears
- [ ] Confirm delete → card disappears; cancel → card stays
- [ ] Visit `/dashboard/not-a-uuid` → 404
- [ ] Visit `/dashboard/valid-uuid-but-not-yours` → 404

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/claude-code)