### PR TITLE
feat: admin panel (Issue #16)

### DIFF
--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -123,6 +123,16 @@ create policy "Users can insert own profile"
   on user_profiles for insert
   with check (auth.uid() = id);
 
+create policy "Admins can update any user profile"
+  on user_profiles for update
+  using (
+    exists (
+      select 1 from user_profiles
+      where user_profiles.id = auth.uid()
+      and user_profiles.role = 'admin'
+    )
+  );
+
 -- Project plans: users can manage their own plans
 create policy "Users can manage own plans"
   on project_plans for all

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -115,9 +115,12 @@ create policy "Profiles are viewable by everyone"
   on user_profiles for select
   using (true);
 
+-- Users can update their own profile but cannot change their own role
+-- with check forces role to equal its current value, preventing self-elevation via direct REST calls
 create policy "Users can update own profile"
   on user_profiles for update
-  using (auth.uid() = id);
+  using (auth.uid() = id)
+  with check (role = (select role from user_profiles where id = auth.uid()));
 
 create policy "Users can insert own profile"
   on user_profiles for insert

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,0 +1,345 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { z } from 'zod';
+import { createServerClient } from '@/lib/supabase/server';
+import {
+  reviewSubmissionSchema,
+  technologyFormSchema,
+  promoteUserSchema,
+} from '@/lib/validators/admin';
+import { isPromotion } from '@/lib/admin/roles';
+import type { ApiResponse } from '@/types/api';
+import type { Technology, UserRole } from '@/types/database';
+
+const idSchema = z.string().uuid('Invalid ID');
+
+// ─── Auth helper ──────────────────────────────────────────────────────────
+
+async function requireAdmin(): Promise<
+  { userId: string } | { error: string }
+> {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { error: 'Unauthorized' };
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('role')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (profile?.role !== 'admin') return { error: 'Forbidden' };
+
+  return { userId: user.id };
+}
+
+// ─── Submission review ────────────────────────────────────────────────────
+
+export async function reviewSubmissionAction(
+  formData: FormData,
+): Promise<ApiResponse<null>> {
+  const auth = await requireAdmin();
+  if ('error' in auth) return { success: false, error: auth.error };
+
+  const raw = {
+    contributionId: formData.get('contributionId'),
+    action: formData.get('action'),
+    reviewNotes: formData.get('reviewNotes') ?? '',
+  };
+
+  const parsed = reviewSubmissionSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0]?.message ?? 'Invalid input' };
+  }
+
+  const { contributionId, action, reviewNotes } = parsed.data;
+  const supabase = await createServerClient();
+
+  // Verify contribution is still pending (race condition guard)
+  const { data: contribution } = await supabase
+    .from('contributions')
+    .select('id, status, technology_data')
+    .eq('id', contributionId)
+    .maybeSingle();
+
+  if (!contribution) return { success: false, error: 'Contribution not found.' };
+  if (contribution.status !== 'pending') {
+    return { success: false, error: 'This submission has already been reviewed.' };
+  }
+
+  if (action === 'approve') {
+    // Validate technology_data before insert
+    const techParsed = technologyFormSchema.safeParse(contribution.technology_data);
+    if (!techParsed.success) {
+      const msg = techParsed.error.issues[0]?.message ?? 'Invalid technology data';
+      return { success: false, error: `Cannot approve: ${msg}` };
+    }
+
+    const { error: insertError } = await supabase
+      .from('technologies')
+      .insert({
+        name: techParsed.data.name,
+        slug: techParsed.data.slug,
+        category: techParsed.data.category,
+        description: techParsed.data.description,
+        logo_url: techParsed.data.logo_url,
+        website_url: techParsed.data.website_url,
+        github_url: techParsed.data.github_url,
+        npm_package: techParsed.data.npm_package,
+        github_stars: techParsed.data.github_stars,
+        npm_weekly_downloads: techParsed.data.npm_weekly_downloads,
+        pros: techParsed.data.pros,
+        cons: techParsed.data.cons,
+        best_for: techParsed.data.best_for,
+        learning_curve: techParsed.data.learning_curve,
+        community_size: techParsed.data.community_size,
+        maturity: techParsed.data.maturity,
+        metadata: techParsed.data.metadata,
+      });
+
+    if (insertError) {
+      // Postgres unique constraint violation on slug
+      if (insertError.code === '23505') {
+        return {
+          success: false,
+          error: `A technology with slug "${techParsed.data.slug}" already exists.`,
+        };
+      }
+      console.error('Failed to insert technology:', insertError);
+      return { success: false, error: 'Failed to add technology. Please try again.' };
+    }
+  }
+
+  // Update contribution status
+  const { error: updateError } = await supabase
+    .from('contributions')
+    .update({
+      status: action === 'approve' ? 'approved' : 'rejected',
+      reviewer_id: auth.userId,
+      review_notes: reviewNotes,
+    })
+    .eq('id', contributionId);
+
+  if (updateError) {
+    console.error('Failed to update contribution status:', updateError);
+    return { success: false, error: 'Failed to update submission status.' };
+  }
+
+  revalidatePath('/admin');
+  return { success: true, data: null };
+}
+
+// ─── Technology management ────────────────────────────────────────────────
+
+export async function createTechnologyAction(
+  formData: FormData,
+): Promise<ApiResponse<Technology>> {
+  const auth = await requireAdmin();
+  if ('error' in auth) return { success: false, error: auth.error };
+
+  const parsed = technologyFormSchema.safeParse(formDataToTechObject(formData));
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0]?.message ?? 'Invalid input' };
+  }
+
+  const supabase = await createServerClient();
+  const { data, error } = await supabase
+    .from('technologies')
+    .insert({
+      name: parsed.data.name,
+      slug: parsed.data.slug,
+      category: parsed.data.category,
+      description: parsed.data.description,
+      logo_url: parsed.data.logo_url,
+      website_url: parsed.data.website_url,
+      github_url: parsed.data.github_url,
+      npm_package: parsed.data.npm_package,
+      github_stars: parsed.data.github_stars,
+      npm_weekly_downloads: parsed.data.npm_weekly_downloads,
+      pros: parsed.data.pros,
+      cons: parsed.data.cons,
+      best_for: parsed.data.best_for,
+      learning_curve: parsed.data.learning_curve,
+      community_size: parsed.data.community_size,
+      maturity: parsed.data.maturity,
+      metadata: parsed.data.metadata,
+    })
+    .select('id, name, slug, category, description, logo_url, website_url, github_url, npm_package, github_stars, npm_weekly_downloads, pros, cons, best_for, learning_curve, community_size, maturity, metadata, created_at, updated_at')
+    .single();
+
+  if (error) {
+    if (error.code === '23505') {
+      return { success: false, error: `A technology with slug "${parsed.data.slug}" already exists.` };
+    }
+    console.error('Failed to create technology:', error);
+    return { success: false, error: 'Failed to create technology.' };
+  }
+
+  revalidatePath('/admin');
+  return { success: true, data };
+}
+
+export async function updateTechnologyAction(
+  formData: FormData,
+): Promise<ApiResponse<Technology>> {
+  const auth = await requireAdmin();
+  if ('error' in auth) return { success: false, error: auth.error };
+
+  const idParsed = idSchema.safeParse(formData.get('id'));
+  if (!idParsed.success) return { success: false, error: 'Invalid technology ID' };
+
+  const parsed = technologyFormSchema.safeParse(formDataToTechObject(formData));
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0]?.message ?? 'Invalid input' };
+  }
+
+  const supabase = await createServerClient();
+  const { data, error } = await supabase
+    .from('technologies')
+    .update({
+      name: parsed.data.name,
+      slug: parsed.data.slug,
+      category: parsed.data.category,
+      description: parsed.data.description,
+      logo_url: parsed.data.logo_url,
+      website_url: parsed.data.website_url,
+      github_url: parsed.data.github_url,
+      npm_package: parsed.data.npm_package,
+      github_stars: parsed.data.github_stars,
+      npm_weekly_downloads: parsed.data.npm_weekly_downloads,
+      pros: parsed.data.pros,
+      cons: parsed.data.cons,
+      best_for: parsed.data.best_for,
+      learning_curve: parsed.data.learning_curve,
+      community_size: parsed.data.community_size,
+      maturity: parsed.data.maturity,
+      metadata: parsed.data.metadata,
+    })
+    .eq('id', idParsed.data)
+    .select('id, name, slug, category, description, logo_url, website_url, github_url, npm_package, github_stars, npm_weekly_downloads, pros, cons, best_for, learning_curve, community_size, maturity, metadata, created_at, updated_at')
+    .single();
+
+  if (error) {
+    if (error.code === '23505') {
+      return { success: false, error: `A technology with slug "${parsed.data.slug}" already exists.` };
+    }
+    console.error('Failed to update technology:', error);
+    return { success: false, error: 'Failed to update technology.' };
+  }
+
+  revalidatePath('/admin');
+  return { success: true, data };
+}
+
+export async function deleteTechnologyAction(
+  formData: FormData,
+): Promise<ApiResponse<null>> {
+  const auth = await requireAdmin();
+  if ('error' in auth) return { success: false, error: auth.error };
+
+  const idParsed = idSchema.safeParse(formData.get('id'));
+  if (!idParsed.success) return { success: false, error: 'Invalid technology ID' };
+
+  const supabase = await createServerClient();
+  const { error } = await supabase
+    .from('technologies')
+    .delete()
+    .eq('id', idParsed.data);
+
+  if (error) {
+    console.error('Failed to delete technology:', error);
+    return { success: false, error: 'Failed to delete technology.' };
+  }
+
+  revalidatePath('/admin');
+  return { success: true, data: null };
+}
+
+// ─── User role management ─────────────────────────────────────────────────
+
+export async function promoteUserAction(
+  formData: FormData,
+): Promise<ApiResponse<null>> {
+  const auth = await requireAdmin();
+  if ('error' in auth) return { success: false, error: auth.error };
+
+  const parsed = promoteUserSchema.safeParse({
+    userId: formData.get('userId'),
+    newRole: formData.get('newRole'),
+  });
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0]?.message ?? 'Invalid input' };
+  }
+
+  const { userId, newRole } = parsed.data;
+
+  if (userId === auth.userId) {
+    return { success: false, error: 'You cannot change your own role.' };
+  }
+
+  const supabase = await createServerClient();
+
+  // Fetch current role to verify this is a promotion
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('role')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (!profile) return { success: false, error: 'User not found.' };
+
+  if (!isPromotion(profile.role as UserRole, newRole)) {
+    return { success: false, error: 'Role can only be promoted, not demoted.' };
+  }
+
+  const { error } = await supabase
+    .from('user_profiles')
+    .update({ role: newRole })
+    .eq('id', userId);
+
+  if (error) {
+    console.error('Failed to promote user:', error);
+    return { success: false, error: 'Failed to update user role.' };
+  }
+
+  revalidatePath('/admin');
+  return { success: true, data: null };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function parseArrayField(value: FormDataEntryValue | null): string[] {
+  if (!value || typeof value !== 'string') return [];
+  return value
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function formDataToTechObject(formData: FormData): Record<string, unknown> {
+  return {
+    name: formData.get('name'),
+    slug: formData.get('slug'),
+    category: formData.get('category'),
+    description: formData.get('description'),
+    logo_url: formData.get('logo_url') ?? null,
+    website_url: formData.get('website_url') ?? null,
+    github_url: formData.get('github_url') ?? null,
+    npm_package: formData.get('npm_package') ?? null,
+    github_stars: formData.get('github_stars') ? Number(formData.get('github_stars')) : null,
+    npm_weekly_downloads: formData.get('npm_weekly_downloads')
+      ? Number(formData.get('npm_weekly_downloads'))
+      : null,
+    pros: parseArrayField(formData.get('pros')),
+    cons: parseArrayField(formData.get('cons')),
+    best_for: parseArrayField(formData.get('best_for')),
+    learning_curve: formData.get('learning_curve'),
+    community_size: formData.get('community_size'),
+    maturity: formData.get('maturity'),
+    metadata: {},
+  };
+}

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -26,11 +26,16 @@ async function requireAdmin(): Promise<
 
   if (!user) return { error: 'Unauthorized' };
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('user_profiles')
     .select('role')
     .eq('id', user.id)
     .maybeSingle();
+
+  if (profileError) {
+    console.error('requireAdmin: profile lookup failed', profileError);
+    return { error: 'Forbidden' };
+  }
 
   if (profile?.role !== 'admin') return { error: 'Forbidden' };
 

--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-8 py-12 text-center max-w-md mx-auto mt-12">
+      <h2 className="text-base font-semibold text-zinc-900">Something went wrong</h2>
+      <p className="mt-2 text-sm text-zinc-500">{error.message}</p>
+      <button
+        onClick={reset}
+        className="mt-4 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/admin/loading.tsx
+++ b/src/app/admin/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="h-8 w-36 animate-pulse rounded bg-zinc-200" />
+      <div className="grid grid-cols-3 gap-4">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="h-20 animate-pulse rounded-xl bg-zinc-100" />
+        ))}
+      </div>
+      <div className="h-64 animate-pulse rounded-xl bg-zinc-100" />
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,71 @@
+export const dynamic = 'force-dynamic';
+
+import { redirect } from 'next/navigation';
+import { createServerClient } from '@/lib/supabase/server';
+import {
+  getAdminDashboardStats,
+  getPendingContributions,
+  getAllTechnologiesAdmin,
+  getAllUserProfiles,
+} from '@/lib/supabase/queries/admin';
+import { AdminAccessDenied } from '@/components/admin/AdminAccessDenied';
+import { DashboardStats } from '@/components/admin/DashboardStats';
+import { AdminTabs } from '@/components/admin/AdminTabs';
+import { SubmissionQueue } from '@/components/admin/SubmissionQueue';
+import { TechnologyManager } from '@/components/admin/TechnologyManager';
+import { UserRoleManager } from '@/components/admin/UserRoleManager';
+
+export default async function AdminPage() {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect('/sign-in');
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('role')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (profile?.role !== 'admin') {
+    return <AdminAccessDenied />;
+  }
+
+  const [stats, contributions, technologies, users] = await Promise.all([
+    getAdminDashboardStats(),
+    getPendingContributions(),
+    getAllTechnologiesAdmin(),
+    getAllUserProfiles(),
+  ]);
+
+  const tabs = [
+    {
+      label: `Dashboard${stats.pendingSubmissions > 0 ? ` (${stats.pendingSubmissions})` : ''}`,
+      content: <DashboardStats stats={stats} />,
+    },
+    {
+      label: `Submissions (${contributions.length})`,
+      content: <SubmissionQueue contributions={contributions} />,
+    },
+    {
+      label: `Technologies (${technologies.length})`,
+      content: <TechnologyManager technologies={technologies} />,
+    },
+    {
+      label: `Users (${users.length})`,
+      content: <UserRoleManager users={users} currentUserId={user.id} />,
+    },
+  ] as const;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-xl font-semibold text-zinc-900">Admin panel</h1>
+        <p className="mt-1 text-sm text-zinc-500">Manage content, review submissions, and configure users.</p>
+      </div>
+      <AdminTabs tabs={tabs} />
+    </div>
+  );
+}

--- a/src/components/admin/AdminAccessDenied.tsx
+++ b/src/components/admin/AdminAccessDenied.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export function AdminAccessDenied() {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-8 py-12 text-center max-w-md mx-auto mt-12">
+      <h2 className="text-base font-semibold text-zinc-900">Access restricted</h2>
+      <p className="mt-2 text-sm text-zinc-500">
+        The admin panel is restricted to administrators only.
+      </p>
+      <Link
+        href="/"
+        className="mt-6 inline-block rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 transition-colors"
+      >
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/src/components/admin/AdminTabs.tsx
+++ b/src/components/admin/AdminTabs.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface AdminTabsProps {
+  tabs: ReadonlyArray<{ label: string; content: React.ReactNode }>;
+}
+
+export function AdminTabs({ tabs }: AdminTabsProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex gap-1 border-b border-zinc-200">
+        {tabs.map((tab, i) => (
+          <button
+            key={tab.label}
+            type="button"
+            onClick={() => setActiveIndex(i)}
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              i === activeIndex
+                ? 'border-zinc-900 text-zinc-900'
+                : 'border-transparent text-zinc-500 hover:text-zinc-700'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div>{tabs[activeIndex]?.content}</div>
+    </div>
+  );
+}

--- a/src/components/admin/DashboardStats.tsx
+++ b/src/components/admin/DashboardStats.tsx
@@ -1,0 +1,33 @@
+import type { AdminDashboardStats } from '@/types/admin';
+
+export interface DashboardStatsProps {
+  stats: AdminDashboardStats;
+}
+
+export function DashboardStats({ stats }: DashboardStatsProps) {
+  const cards = [
+    { label: 'Pending submissions', value: stats.pendingSubmissions, highlight: stats.pendingSubmissions > 0 },
+    { label: 'Total technologies', value: stats.totalTechnologies, highlight: false },
+    { label: 'Total users', value: stats.totalUsers, highlight: false },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      {cards.map(({ label, value, highlight }) => (
+        <div
+          key={label}
+          className={`rounded-xl border px-6 py-5 ${
+            highlight
+              ? 'border-amber-200 bg-amber-50'
+              : 'border-zinc-200 bg-white'
+          }`}
+        >
+          <p className="text-xs font-medium text-zinc-500">{label}</p>
+          <p className={`mt-1 text-3xl font-semibold ${highlight ? 'text-amber-700' : 'text-zinc-900'}`}>
+            {value}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/admin/SubmissionQueue.tsx
+++ b/src/components/admin/SubmissionQueue.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { reviewSubmissionAction } from '@/app/admin/actions';
+import type { ContributionWithContributor } from '@/types/admin';
+
+export interface SubmissionQueueProps {
+  contributions: ContributionWithContributor[];
+}
+
+export function SubmissionQueue({ contributions }: SubmissionQueueProps) {
+  if (contributions.length === 0) {
+    return (
+      <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-8 text-center">
+        <p className="text-sm text-zinc-500">No pending submissions.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {contributions.map((contribution) => (
+        <SubmissionCard key={contribution.id} contribution={contribution} />
+      ))}
+    </div>
+  );
+}
+
+function SubmissionCard({ contribution }: { contribution: ContributionWithContributor }) {
+  const [expanded, setExpanded] = useState(false);
+  const [notes, setNotes] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const techName =
+    typeof contribution.technology_data?.name === 'string'
+      ? contribution.technology_data.name
+      : 'Untitled';
+
+  function handleAction(action: 'approve' | 'reject') {
+    setError(null);
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set('contributionId', contribution.id);
+      formData.set('action', action);
+      formData.set('reviewNotes', notes);
+      const result = await reviewSubmissionAction(formData);
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      setDone(true);
+    });
+  }
+
+  if (done) {
+    return (
+      <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+        Submission reviewed.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-zinc-200 bg-white p-4 flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-zinc-900">{techName}</p>
+          <p className="mt-0.5 text-xs text-zinc-400">
+            by {contribution.contributor_display_name} &middot;{' '}
+            {new Date(contribution.created_at).toLocaleDateString('en-US', {
+              month: 'short', day: 'numeric', year: 'numeric',
+            })}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="text-xs text-zinc-500 hover:text-zinc-900 transition-colors shrink-0"
+        >
+          {expanded ? 'Hide details' : 'Show details'}
+        </button>
+      </div>
+
+      {expanded && (
+        <pre className="rounded-md bg-zinc-50 border border-zinc-200 p-3 text-xs text-zinc-700 overflow-auto max-h-64 whitespace-pre-wrap">
+          {JSON.stringify(contribution.technology_data, null, 2)}
+        </pre>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Reviewer notes (optional)"
+          rows={2}
+          maxLength={500}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => handleAction('approve')}
+            disabled={isPending}
+            className="rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700 transition-colors disabled:opacity-50"
+          >
+            {isPending ? 'Processing…' : 'Approve'}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAction('reject')}
+            disabled={isPending}
+            className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 transition-colors disabled:opacity-50"
+          >
+            {isPending ? 'Processing…' : 'Reject'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/TechnologyManager.tsx
+++ b/src/components/admin/TechnologyManager.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import {
+  createTechnologyAction,
+  updateTechnologyAction,
+  deleteTechnologyAction,
+} from '@/app/admin/actions';
+import type { Technology } from '@/types/database';
+
+export interface TechnologyManagerProps {
+  technologies: Technology[];
+}
+
+type ViewMode = 'list' | 'create' | 'edit';
+
+export function TechnologyManager({ technologies: initialTechs }: TechnologyManagerProps) {
+  const [techs, setTechs] = useState(initialTechs);
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [editing, setEditing] = useState<Technology | null>(null);
+
+  function handleEdit(tech: Technology) {
+    setEditing(tech);
+    setViewMode('edit');
+  }
+
+  function handleCreate() {
+    setEditing(null);
+    setViewMode('create');
+  }
+
+  function handleBack() {
+    setEditing(null);
+    setViewMode('list');
+  }
+
+  function handleSaved(tech: Technology) {
+    setTechs((prev) => {
+      const idx = prev.findIndex((t) => t.id === tech.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = tech;
+        return next;
+      }
+      return [tech, ...prev];
+    });
+    handleBack();
+  }
+
+  function handleDeleted(id: string) {
+    setTechs((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  if (viewMode === 'create' || viewMode === 'edit') {
+    return (
+      <TechnologyForm
+        technology={editing}
+        onSaved={handleSaved}
+        onCancel={handleBack}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-zinc-500">{techs.length} technologies</p>
+        <button
+          type="button"
+          onClick={handleCreate}
+          className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-zinc-700 transition-colors"
+        >
+          Add technology
+        </button>
+      </div>
+
+      {techs.length === 0 ? (
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-8 text-center">
+          <p className="text-sm text-zinc-500">No technologies yet.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {techs.map((tech) => (
+            <TechnologyRow
+              key={tech.id}
+              technology={tech}
+              onEdit={() => handleEdit(tech)}
+              onDeleted={() => handleDeleted(tech.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TechnologyRow({
+  technology,
+  onEdit,
+  onDeleted,
+}: {
+  technology: Technology;
+  onEdit: () => void;
+  onDeleted: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    setError(null);
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set('id', technology.id);
+      const result = await deleteTechnologyAction(formData);
+      if (!result.success) {
+        setError(result.error);
+        setConfirming(false);
+        return;
+      }
+      onDeleted();
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-zinc-200 bg-white px-4 py-3">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-zinc-900 truncate">{technology.name}</p>
+        <p className="text-xs text-zinc-400">{technology.slug} &middot; {technology.category}</p>
+        {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+      </div>
+      <div className="flex items-center gap-3 ml-4 shrink-0">
+        <button
+          type="button"
+          onClick={onEdit}
+          className="text-xs text-zinc-500 hover:text-zinc-900 transition-colors"
+        >
+          Edit
+        </button>
+        {confirming ? (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-zinc-500">Delete &ldquo;{technology.name}&rdquo;?</span>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isPending}
+              className="rounded px-2 py-1 text-xs font-medium bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50"
+            >
+              {isPending ? 'Deleting…' : 'Confirm'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              className="text-xs text-zinc-500 hover:text-zinc-900 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="text-xs text-zinc-400 hover:text-red-600 transition-colors"
+          >
+            Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TechnologyForm({
+  technology,
+  onSaved,
+  onCancel,
+}: {
+  technology: Technology | null;
+  onSaved: (tech: Technology) => void;
+  onCancel: () => void;
+}) {
+  const isEdit = technology !== null;
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const [arrayFields, setArrayFields] = useState({
+    pros: (technology?.pros ?? ['']).join('\n'),
+    cons: (technology?.cons ?? ['']).join('\n'),
+    best_for: (technology?.best_for ?? ['']).join('\n'),
+  });
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    formData.set('pros', arrayFields.pros);
+    formData.set('cons', arrayFields.cons);
+    formData.set('best_for', arrayFields.best_for);
+
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateTechnologyAction(formData)
+        : await createTechnologyAction(formData);
+
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      onSaved(result.data);
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-xs text-zinc-500 hover:text-zinc-900 transition-colors"
+        >
+          ← Back
+        </button>
+        <h3 className="text-sm font-semibold text-zinc-900">
+          {isEdit ? `Edit: ${technology.name}` : 'Add technology'}
+        </h3>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {isEdit && <input type="hidden" name="id" value={technology.id} />}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="Name" required>
+          <input name="name" defaultValue={technology?.name ?? ''} required maxLength={100} className={inputClass} />
+        </Field>
+        <Field label="Slug" required hint="Lowercase kebab-case">
+          <input name="slug" defaultValue={technology?.slug ?? ''} required maxLength={100} pattern="[a-z0-9]+(-[a-z0-9]+)*" className={inputClass} />
+        </Field>
+        <Field label="Category" required>
+          <input name="category" defaultValue={technology?.category ?? ''} required maxLength={50} className={inputClass} />
+        </Field>
+        <Field label="Learning curve" required>
+          <select name="learning_curve" defaultValue={technology?.learning_curve ?? 'intermediate'} required className={inputClass}>
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="advanced">Advanced</option>
+          </select>
+        </Field>
+        <Field label="Community size" required>
+          <select name="community_size" defaultValue={technology?.community_size ?? 'medium'} required className={inputClass}>
+            <option value="small">Small</option>
+            <option value="medium">Medium</option>
+            <option value="large">Large</option>
+          </select>
+        </Field>
+        <Field label="Maturity" required>
+          <select name="maturity" defaultValue={technology?.maturity ?? 'growing'} required className={inputClass}>
+            <option value="emerging">Emerging</option>
+            <option value="growing">Growing</option>
+            <option value="mature">Mature</option>
+            <option value="declining">Declining</option>
+          </select>
+        </Field>
+      </div>
+
+      <Field label="Description" required>
+        <textarea name="description" defaultValue={technology?.description ?? ''} required maxLength={2000} rows={3} className={inputClass} />
+      </Field>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Field label="Logo URL">
+          <input name="logo_url" defaultValue={technology?.logo_url ?? ''} type="url" className={inputClass} />
+        </Field>
+        <Field label="Website URL">
+          <input name="website_url" defaultValue={technology?.website_url ?? ''} type="url" className={inputClass} />
+        </Field>
+        <Field label="GitHub URL">
+          <input name="github_url" defaultValue={technology?.github_url ?? ''} type="url" className={inputClass} />
+        </Field>
+        <Field label="npm package">
+          <input name="npm_package" defaultValue={technology?.npm_package ?? ''} maxLength={214} className={inputClass} />
+        </Field>
+        <Field label="GitHub stars">
+          <input name="github_stars" defaultValue={technology?.github_stars ?? ''} type="number" min={0} step={1} className={inputClass} />
+        </Field>
+        <Field label="npm weekly downloads">
+          <input name="npm_weekly_downloads" defaultValue={technology?.npm_weekly_downloads ?? ''} type="number" min={0} step={1} className={inputClass} />
+        </Field>
+      </div>
+
+      {(['pros', 'cons', 'best_for'] as const).map((field) => (
+        <Field key={field} label={field.replace('_', ' ')} hint="One per line, 1–10 items" required>
+          <textarea
+            value={arrayFields[field]}
+            onChange={(e) => setArrayFields((prev) => ({ ...prev, [field]: e.target.value }))}
+            rows={3}
+            maxLength={2500}
+            className={inputClass}
+            placeholder="One item per line"
+          />
+        </Field>
+      ))}
+
+      <div className="flex items-center gap-3 pt-1">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 transition-colors disabled:opacity-50"
+        >
+          {isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create technology'}
+        </button>
+        <button type="button" onClick={onCancel} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+const inputClass =
+  'w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500';
+
+interface FieldProps {
+  label: string;
+  hint?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+function Field({ label, hint, required, children }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs font-medium text-zinc-700">
+        {label}
+        {required && <span className="ml-0.5 text-red-500">*</span>}
+      </label>
+      {hint && <p className="text-xs text-zinc-400">{hint}</p>}
+      {children}
+    </div>
+  );
+}

--- a/src/components/admin/UserRoleManager.tsx
+++ b/src/components/admin/UserRoleManager.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { promoteUserAction } from '@/app/admin/actions';
+import { canPromoteTo } from '@/lib/admin/roles';
+import type { UserProfile, UserRole } from '@/types/database';
+
+export interface UserRoleManagerProps {
+  users: UserProfile[];
+  currentUserId: string;
+}
+
+export function UserRoleManager({ users: initialUsers, currentUserId }: UserRoleManagerProps) {
+  const [users, setUsers] = useState(initialUsers);
+
+  function handlePromoted(userId: string, newRole: UserRole) {
+    setUsers((prev) =>
+      prev.map((u) => (u.id === userId ? { ...u, role: newRole } : u)),
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {users.map((user) => (
+        <UserRow
+          key={user.id}
+          user={user}
+          isSelf={user.id === currentUserId}
+          onPromoted={(newRole) => handlePromoted(user.id, newRole)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function UserRow({
+  user,
+  isSelf,
+  onPromoted,
+}: {
+  user: UserProfile;
+  isSelf: boolean;
+  onPromoted: (newRole: UserRole) => void;
+}) {
+  const promotionTargets = canPromoteTo(user.role);
+  const [selectedRole, setSelectedRole] = useState<UserRole>(
+    promotionTargets[0] ?? user.role,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handlePromote() {
+    setError(null);
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set('userId', user.id);
+      formData.set('newRole', selectedRole);
+      const result = await promoteUserAction(formData);
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      onPromoted(selectedRole);
+    });
+  }
+
+  const roleBadgeClass: Record<UserRole, string> = {
+    developer: 'bg-zinc-100 text-zinc-700',
+    contributor: 'bg-blue-100 text-blue-700',
+    admin: 'bg-purple-100 text-purple-700',
+  };
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-zinc-200 bg-white px-4 py-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium text-zinc-900 truncate">{user.display_name}</p>
+          {isSelf && <span className="text-xs text-zinc-400">(you)</span>}
+        </div>
+        <div className="mt-0.5 flex items-center gap-2">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${roleBadgeClass[user.role]}`}
+          >
+            {user.role}
+          </span>
+          {error && <span className="text-xs text-red-600">{error}</span>}
+        </div>
+      </div>
+
+      {!isSelf && promotionTargets.length > 0 && (
+        <div className="flex items-center gap-2 ml-4 shrink-0">
+          <select
+            value={selectedRole}
+            onChange={(e) => setSelectedRole(e.target.value as UserRole)}
+            className="rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-400"
+          >
+            {promotionTargets.map((role) => (
+              <option key={role} value={role}>
+                {role}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={handlePromote}
+            disabled={isPending}
+            className="rounded px-2 py-1 text-xs font-medium bg-zinc-900 text-white hover:bg-zinc-700 transition-colors disabled:opacity-50"
+          >
+            {isPending ? 'Promoting…' : 'Promote'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/admin/__tests__/roles.test.ts
+++ b/src/lib/admin/__tests__/roles.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { isPromotion, canPromoteTo } from '../roles';
+
+describe('isPromotion', () => {
+  it('developer → contributor is a promotion', () => {
+    expect(isPromotion('developer', 'contributor')).toBe(true);
+  });
+
+  it('developer → admin is a promotion', () => {
+    expect(isPromotion('developer', 'admin')).toBe(true);
+  });
+
+  it('contributor → admin is a promotion', () => {
+    expect(isPromotion('contributor', 'admin')).toBe(true);
+  });
+
+  it('admin → developer is NOT a promotion (demotion)', () => {
+    expect(isPromotion('admin', 'developer')).toBe(false);
+  });
+
+  it('admin → contributor is NOT a promotion (demotion)', () => {
+    expect(isPromotion('admin', 'contributor')).toBe(false);
+  });
+
+  it('contributor → developer is NOT a promotion (demotion)', () => {
+    expect(isPromotion('contributor', 'developer')).toBe(false);
+  });
+
+  it('same role is NOT a promotion', () => {
+    expect(isPromotion('developer', 'developer')).toBe(false);
+    expect(isPromotion('contributor', 'contributor')).toBe(false);
+    expect(isPromotion('admin', 'admin')).toBe(false);
+  });
+});
+
+describe('canPromoteTo', () => {
+  it('developer can be promoted to contributor or admin', () => {
+    const targets = canPromoteTo('developer');
+    expect(targets).toContain('contributor');
+    expect(targets).toContain('admin');
+    expect(targets).not.toContain('developer');
+  });
+
+  it('contributor can be promoted to admin only', () => {
+    const targets = canPromoteTo('contributor');
+    expect(targets).toEqual(['admin']);
+  });
+
+  it('admin cannot be promoted (already top role)', () => {
+    const targets = canPromoteTo('admin');
+    expect(targets).toEqual([]);
+  });
+});

--- a/src/lib/admin/index.ts
+++ b/src/lib/admin/index.ts
@@ -1,0 +1,1 @@
+export { isPromotion, canPromoteTo } from './roles';

--- a/src/lib/admin/roles.ts
+++ b/src/lib/admin/roles.ts
@@ -1,0 +1,14 @@
+import type { UserRole } from '@/types/database';
+import { ROLE_HIERARCHY } from '@/types/admin';
+
+/** Returns true only if newRole is strictly higher than currentRole in the hierarchy */
+export function isPromotion(currentRole: UserRole, newRole: UserRole): boolean {
+  return ROLE_HIERARCHY[newRole] > ROLE_HIERARCHY[currentRole];
+}
+
+/** Returns the list of roles a user can be promoted to (all roles strictly above current) */
+export function canPromoteTo(currentRole: UserRole): UserRole[] {
+  return (Object.keys(ROLE_HIERARCHY) as UserRole[]).filter(
+    (role) => ROLE_HIERARCHY[role] > ROLE_HIERARCHY[currentRole],
+  );
+}

--- a/src/lib/supabase/queries/admin.ts
+++ b/src/lib/supabase/queries/admin.ts
@@ -1,0 +1,107 @@
+import { createServerClient } from '@/lib/supabase/server';
+import type { Technology, UserProfile, Contribution } from '@/types/database';
+import type { AdminDashboardStats, ContributionWithContributor } from '@/types/admin';
+
+export async function getAdminDashboardStats(): Promise<AdminDashboardStats> {
+  const supabase = await createServerClient();
+
+  const [pendingResult, techResult, usersResult] = await Promise.all([
+    supabase
+      .from('contributions')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'pending'),
+    supabase
+      .from('technologies')
+      .select('id', { count: 'exact', head: true }),
+    supabase
+      .from('user_profiles')
+      .select('id', { count: 'exact', head: true }),
+  ]);
+
+  return {
+    pendingSubmissions: pendingResult.count ?? 0,
+    totalTechnologies: techResult.count ?? 0,
+    totalUsers: usersResult.count ?? 0,
+  };
+}
+
+export async function getPendingContributions(): Promise<ContributionWithContributor[]> {
+  const supabase = await createServerClient();
+
+  const { data: contributions, error } = await supabase
+    .from('contributions')
+    .select('id, contributor_id, technology_data, status, reviewer_id, review_notes, created_at, updated_at')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(50);
+
+  if (error || !contributions || contributions.length === 0) {
+    if (error) console.error('Failed to fetch pending contributions:', error);
+    return [];
+  }
+
+  // Batch-fetch contributor display names
+  const contributorIds = [...new Set(contributions.map((c) => c.contributor_id))];
+  const { data: profiles } = await supabase
+    .from('user_profiles')
+    .select('id, display_name')
+    .in('id', contributorIds);
+
+  const profileMap = new Map((profiles ?? []).map((p) => [p.id, p.display_name]));
+
+  return contributions.map((c) => ({
+    ...(c as Contribution),
+    contributor_display_name: profileMap.get(c.contributor_id) ?? 'Unknown',
+  }));
+}
+
+export async function getAllTechnologiesAdmin(): Promise<Technology[]> {
+  const supabase = await createServerClient();
+
+  const { data, error } = await supabase
+    .from('technologies')
+    .select('id, name, slug, category, description, logo_url, website_url, github_url, npm_package, github_stars, npm_weekly_downloads, pros, cons, best_for, learning_curve, community_size, maturity, metadata, created_at, updated_at')
+    .order('name')
+    .limit(200);
+
+  if (error) {
+    console.error('Failed to fetch technologies:', error);
+    return [];
+  }
+
+  return data ?? [];
+}
+
+export async function getTechnologyByIdAdmin(id: string): Promise<Technology | null> {
+  const supabase = await createServerClient();
+
+  const { data, error } = await supabase
+    .from('technologies')
+    .select('id, name, slug, category, description, logo_url, website_url, github_url, npm_package, github_stars, npm_weekly_downloads, pros, cons, best_for, learning_curve, community_size, maturity, metadata, created_at, updated_at')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Failed to fetch technology:', error);
+    return null;
+  }
+
+  return data ?? null;
+}
+
+export async function getAllUserProfiles(): Promise<UserProfile[]> {
+  const supabase = await createServerClient();
+
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .select('id, display_name, role, avatar_url, created_at, updated_at')
+    .order('created_at', { ascending: true })
+    .limit(200);
+
+  if (error) {
+    console.error('Failed to fetch user profiles:', error);
+    return [];
+  }
+
+  return data ?? [];
+}

--- a/src/lib/validators/__tests__/admin.test.ts
+++ b/src/lib/validators/__tests__/admin.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { reviewSubmissionSchema, technologyFormSchema, promoteUserSchema } from '../admin';
+
+// ─── reviewSubmissionSchema ───────────────────────────────────────────────
+
+describe('reviewSubmissionSchema', () => {
+  const VALID_APPROVE = {
+    contributionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+    action: 'approve' as const,
+    reviewNotes: '',
+  };
+
+  it('accepts valid approve input', () => {
+    expect(reviewSubmissionSchema.safeParse(VALID_APPROVE).success).toBe(true);
+  });
+
+  it('accepts valid reject input with notes', () => {
+    const input = { ...VALID_APPROVE, action: 'reject' as const, reviewNotes: 'Needs more detail' };
+    expect(reviewSubmissionSchema.safeParse(input).success).toBe(true);
+  });
+
+  it('defaults reviewNotes to empty string when omitted', () => {
+    const { reviewNotes: _, ...rest } = VALID_APPROVE; // eslint-disable-line @typescript-eslint/no-unused-vars
+    const result = reviewSubmissionSchema.safeParse(rest);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.reviewNotes).toBe('');
+  });
+
+  it('rejects non-UUID contributionId', () => {
+    expect(reviewSubmissionSchema.safeParse({ ...VALID_APPROVE, contributionId: 'not-a-uuid' }).success).toBe(false);
+  });
+
+  it('rejects invalid action value', () => {
+    expect(reviewSubmissionSchema.safeParse({ ...VALID_APPROVE, action: 'maybe' }).success).toBe(false);
+  });
+
+  it('rejects reviewNotes exceeding 500 chars', () => {
+    expect(reviewSubmissionSchema.safeParse({ ...VALID_APPROVE, reviewNotes: 'x'.repeat(501) }).success).toBe(false);
+  });
+});
+
+// ─── technologyFormSchema ─────────────────────────────────────────────────
+
+describe('technologyFormSchema', () => {
+  const VALID_TECH = {
+    name: 'React',
+    slug: 'react',
+    category: 'library',
+    description: 'A JavaScript library for building user interfaces.',
+    logo_url: null,
+    website_url: null,
+    github_url: null,
+    npm_package: null,
+    github_stars: null,
+    npm_weekly_downloads: null,
+    pros: ['Composable', 'Large ecosystem'],
+    cons: ['JSX learning curve'],
+    best_for: ['Web apps', 'SPAs'],
+    learning_curve: 'intermediate' as const,
+    community_size: 'large' as const,
+    maturity: 'mature' as const,
+    metadata: {},
+  };
+
+  it('accepts a fully valid technology', () => {
+    expect(technologyFormSchema.safeParse(VALID_TECH).success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    expect(technologyFormSchema.safeParse({ ...VALID_TECH, name: '' }).success).toBe(false);
+  });
+
+  it('rejects invalid slug (uppercase)', () => {
+    expect(technologyFormSchema.safeParse({ ...VALID_TECH, slug: 'React-JS' }).success).toBe(false);
+  });
+
+  it('rejects invalid learning_curve value', () => {
+    expect(technologyFormSchema.safeParse({ ...VALID_TECH, learning_curve: 'expert' }).success).toBe(false);
+  });
+
+  it('rejects invalid community_size value', () => {
+    expect(technologyFormSchema.safeParse({ ...VALID_TECH, community_size: 'huge' }).success).toBe(false);
+  });
+
+  it('rejects invalid maturity value', () => {
+    expect(technologyFormSchema.safeParse({ ...VALID_TECH, maturity: 'legacy' }).success).toBe(false);
+  });
+
+  it('rejects empty pros array', () => {
+    expect(technologyFormSchema.safeParse({ ...VALID_TECH, pros: [] }).success).toBe(false);
+  });
+
+  it('rejects negative github_stars', () => {
+    expect(technologyFormSchema.safeParse({ ...VALID_TECH, github_stars: -1 }).success).toBe(false);
+  });
+
+  it('accepts valid URL strings', () => {
+    const result = technologyFormSchema.safeParse({
+      ...VALID_TECH,
+      website_url: 'https://react.dev',
+      github_url: 'https://github.com/facebook/react',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid URL', () => {
+    expect(technologyFormSchema.safeParse({ ...VALID_TECH, website_url: 'not-a-url' }).success).toBe(false);
+  });
+
+  it('coerces empty string URL to null', () => {
+    const result = technologyFormSchema.safeParse({ ...VALID_TECH, website_url: '' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.website_url).toBeNull();
+  });
+
+  it('defaults metadata to empty object when omitted', () => {
+    const { metadata: _, ...rest } = VALID_TECH; // eslint-disable-line @typescript-eslint/no-unused-vars
+    const result = technologyFormSchema.safeParse(rest);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.metadata).toEqual({});
+  });
+});
+
+// ─── promoteUserSchema ────────────────────────────────────────────────────
+
+describe('promoteUserSchema', () => {
+  const VALID = {
+    userId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+    newRole: 'contributor' as const,
+  };
+
+  it('accepts valid promote input', () => {
+    expect(promoteUserSchema.safeParse(VALID).success).toBe(true);
+  });
+
+  it('rejects non-UUID userId', () => {
+    expect(promoteUserSchema.safeParse({ ...VALID, userId: 'not-a-uuid' }).success).toBe(false);
+  });
+
+  it('accepts all valid roles', () => {
+    for (const role of ['developer', 'contributor', 'admin'] as const) {
+      expect(promoteUserSchema.safeParse({ ...VALID, newRole: role }).success).toBe(true);
+    }
+  });
+
+  it('rejects invalid role', () => {
+    expect(promoteUserSchema.safeParse({ ...VALID, newRole: 'superadmin' }).success).toBe(false);
+  });
+});

--- a/src/lib/validators/__tests__/admin.test.ts
+++ b/src/lib/validators/__tests__/admin.test.ts
@@ -120,6 +120,18 @@ describe('technologyFormSchema', () => {
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.metadata).toEqual({});
   });
+
+  it('coerces empty string npm_package to null', () => {
+    const result = technologyFormSchema.safeParse({ ...VALID_TECH, npm_package: '' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.npm_package).toBeNull();
+  });
+
+  it('accepts a non-empty npm_package string', () => {
+    const result = technologyFormSchema.safeParse({ ...VALID_TECH, npm_package: 'react' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.npm_package).toBe('react');
+  });
 });
 
 // ─── promoteUserSchema ────────────────────────────────────────────────────

--- a/src/lib/validators/__tests__/admin.test.ts
+++ b/src/lib/validators/__tests__/admin.test.ts
@@ -150,10 +150,14 @@ describe('promoteUserSchema', () => {
     expect(promoteUserSchema.safeParse({ ...VALID, userId: 'not-a-uuid' }).success).toBe(false);
   });
 
-  it('accepts all valid roles', () => {
-    for (const role of ['developer', 'contributor', 'admin'] as const) {
+  it('accepts contributor and admin as valid promotion targets', () => {
+    for (const role of ['contributor', 'admin'] as const) {
       expect(promoteUserSchema.safeParse({ ...VALID, newRole: role }).success).toBe(true);
     }
+  });
+
+  it('rejects developer as newRole (demotion not allowed)', () => {
+    expect(promoteUserSchema.safeParse({ ...VALID, newRole: 'developer' }).success).toBe(false);
   });
 
   it('rejects invalid role', () => {

--- a/src/lib/validators/admin.ts
+++ b/src/lib/validators/admin.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+const optionalUrl = z
+  .string()
+  .transform((v) => (v === '' ? null : v))
+  .pipe(z.string().url().nullable())
+  .nullable()
+  .default(null);
+
+const optionalString = z
+  .string()
+  .transform((v) => (v === '' ? null : v))
+  .pipe(z.string().max(214).nullable())
+  .nullable()
+  .default(null);
+
+const arrayOfStrings = z.array(z.string().min(1).max(200)).min(1).max(10);
+
+export const reviewSubmissionSchema = z.object({
+  contributionId: z.string().uuid('Invalid contribution ID'),
+  action: z.enum(['approve', 'reject']),
+  reviewNotes: z.string().max(500).default(''),
+});
+
+export const technologyFormSchema = z.object({
+  name: z.string().min(1).max(100),
+  slug: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be lowercase kebab-case'),
+  category: z.string().min(1).max(50),
+  description: z.string().min(1).max(2000),
+  logo_url: optionalUrl,
+  website_url: optionalUrl,
+  github_url: optionalUrl,
+  npm_package: optionalString,
+  github_stars: z.number().int().min(0).nullable().default(null),
+  npm_weekly_downloads: z.number().int().min(0).nullable().default(null),
+  pros: arrayOfStrings,
+  cons: arrayOfStrings,
+  best_for: arrayOfStrings,
+  learning_curve: z.enum(['beginner', 'intermediate', 'advanced']),
+  community_size: z.enum(['small', 'medium', 'large']),
+  maturity: z.enum(['emerging', 'growing', 'mature', 'declining']),
+  metadata: z.record(z.string(), z.unknown()).default({}),
+});
+
+export const promoteUserSchema = z.object({
+  userId: z.string().uuid('Invalid user ID'),
+  newRole: z.enum(['developer', 'contributor', 'admin']),
+});
+
+export type ReviewSubmissionInput = z.infer<typeof reviewSubmissionSchema>;
+export type TechnologyFormInput = z.infer<typeof technologyFormSchema>;
+export type PromoteUserInput = z.infer<typeof promoteUserSchema>;

--- a/src/lib/validators/admin.ts
+++ b/src/lib/validators/admin.ts
@@ -43,12 +43,18 @@ export const technologyFormSchema = z.object({
   learning_curve: z.enum(['beginner', 'intermediate', 'advanced']),
   community_size: z.enum(['small', 'medium', 'large']),
   maturity: z.enum(['emerging', 'growing', 'mature', 'declining']),
-  metadata: z.record(z.string(), z.unknown()).default({}),
+  metadata: z
+    .record(
+      z.string().max(50),
+      z.union([z.string().max(500), z.number(), z.boolean(), z.null()]),
+    )
+    .default({}),
 });
 
 export const promoteUserSchema = z.object({
   userId: z.string().uuid('Invalid user ID'),
-  newRole: z.enum(['developer', 'contributor', 'admin']),
+  // 'developer' excluded — promotion only, never demotion
+  newRole: z.enum(['contributor', 'admin']),
 });
 
 export type ReviewSubmissionInput = z.infer<typeof reviewSubmissionSchema>;

--- a/src/lib/validators/index.ts
+++ b/src/lib/validators/index.ts
@@ -1,2 +1,5 @@
 export { technologySubmissionSchema } from './contribution';
 export type { TechnologySubmissionInput } from './contribution';
+
+export { reviewSubmissionSchema, technologyFormSchema, promoteUserSchema } from './admin';
+export type { ReviewSubmissionInput, TechnologyFormInput, PromoteUserInput } from './admin';

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,0 +1,17 @@
+import type { Contribution, UserRole } from '@/types/database';
+
+export interface AdminDashboardStats {
+  pendingSubmissions: number;
+  totalTechnologies: number;
+  totalUsers: number;
+}
+
+export interface ContributionWithContributor extends Contribution {
+  contributor_display_name: string;
+}
+
+export const ROLE_HIERARCHY = {
+  developer: 0,
+  contributor: 1,
+  admin: 2,
+} as const satisfies Record<UserRole, number>;


### PR DESCRIPTION
## Summary
- Admin-only panel at \`/admin\` with four tabbed sections: dashboard stats, submission review queue, technology CRUD, and user role management
- Non-admin authenticated users see an access-denied page (not a redirect)
- All mutations are server actions with \`requireAdmin()\` guard — role enforced independently of the page layer

## What was built
- **Dashboard**: pending submissions count, total technologies, total users — fetched in parallel
- **Submission review**: approve (inserts into technologies) or reject with reviewer notes; slug collision handled gracefully with a user-facing error; contribution stays pending on failure
- **Technology CRUD**: list all technologies, full edit form (all 17 fields), hard delete with confirmation step
- **User role management**: list all users with roles, promote-only (developer → contributor → admin, no demotion), admin cannot change own role

## Security findings resolved
- **H1 (Critical)**: `user_profiles` self-update RLS policy now uses `WITH CHECK (role = current_role)` — prevents any user from elevating their own role via direct Supabase REST API calls
- **L1**: `promoteUserSchema` excludes `'developer'` from `newRole` — schema enforces promotion-only at the validation layer
- **M2**: `metadata` field capped to scalar values with max key/value lengths
- **M3**: `requireAdmin()` now explicitly logs profile lookup errors

## Tests
- 35 new unit tests (10 roles + 25 validators) — TDD red-green-refactor
- Coverage: \`lib/admin/roles.ts\` 100%, \`lib/validators/admin.ts\` 100%

## Test plan
- [ ] \`npm run test\` — 152 tests pass
- [ ] \`npm run typecheck\` — zero errors
- [ ] \`npm run build\` — clean build, \`/admin\` renders as dynamic
- [ ] Unauthenticated user → redirected to \`/sign-in\`
- [ ] Authenticated developer → sees access-denied page
- [ ] Admin → sees 4 tabs with live data
- [ ] Admin approves valid submission → technology appears, contribution marked approved
- [ ] Admin approves submission with duplicate slug → error shown, contribution stays pending
- [ ] Admin rejects submission with notes → contribution marked rejected
- [ ] Admin edits a technology → all fields update
- [ ] Admin deletes technology → confirm step, then removed
- [ ] Admin promotes developer → role updates
- [ ] Admin cannot change their own role

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)