### PR TITLE
feat: wizard compare panel, edit saved plans, and dashboard edit links

### DIFF
--- a/src/app/dashboard/[planId]/page.tsx
+++ b/src/app/dashboard/[planId]/page.tsx
@@ -59,19 +59,27 @@ export default async function PlanDetailPage({ params }: PlanDetailPageProps) {
         <span className="text-zinc-600">{plan.name}</span>
       </div>
 
-      <div>
-        <h1 className="text-xl font-semibold text-zinc-900">{plan.name}</h1>
-        {plan.description && (
-          <p className="mt-1 text-sm text-zinc-500">{plan.description}</p>
-        )}
-        <p className="mt-1 text-xs text-zinc-400">
-          Created{' '}
-          {new Date(plan.created_at).toLocaleDateString('en-US', {
-            month: 'long',
-            day: 'numeric',
-            year: 'numeric',
-          })}
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold text-zinc-900">{plan.name}</h1>
+          {plan.description && (
+            <p className="mt-1 text-sm text-zinc-500">{plan.description}</p>
+          )}
+          <p className="mt-1 text-xs text-zinc-400">
+            Created{' '}
+            {new Date(plan.created_at).toLocaleDateString('en-US', {
+              month: 'long',
+              day: 'numeric',
+              year: 'numeric',
+            })}
+          </p>
+        </div>
+        <Link
+          href={`/wizard/edit/${plan.id}`}
+          className="shrink-0 rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 hover:border-zinc-300 hover:bg-zinc-50 transition-colors"
+        >
+          Edit plan
+        </Link>
       </div>
 
       {configResult ? (

--- a/src/components/dashboard/PlanCard.tsx
+++ b/src/components/dashboard/PlanCard.tsx
@@ -33,14 +33,22 @@ export function PlanCard({ plan }: PlanCardProps) {
         <p className="text-sm leading-relaxed text-zinc-500 line-clamp-2">{plan.description}</p>
       )}
 
-      <div className="mt-auto flex items-center justify-between border-t border-zinc-100 pt-3">
+      <div className="mt-auto flex items-center justify-between gap-2 border-t border-zinc-100 pt-3">
         <span className="text-xs text-zinc-400">{formatDate(plan.created_at)}</span>
-        <Link
-          href={`/dashboard/${plan.id}`}
-          className="text-xs font-medium text-zinc-500 hover:text-zinc-900 transition-colors"
-        >
-          View configs →
-        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/wizard/edit/${plan.id}`}
+            className="text-xs font-medium text-zinc-400 hover:text-zinc-700 transition-colors"
+          >
+            Edit
+          </Link>
+          <Link
+            href={`/dashboard/${plan.id}`}
+            className="text-xs font-medium text-zinc-500 hover:text-zinc-900 transition-colors"
+          >
+            View configs →
+          </Link>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Compare panel in wizard steps** (closes #49): Each wizard step now has a **Compare** button that opens a slide-over panel. Users pick any two options from that step to see a full side-by-side comparison — same CategoryScoreBar, ComparisonSummaryPanel, and score cards as the `/compare` page.
- **Edit saved plans** (closes #50): Users can now edit any previously saved plan. The wizard loads pre-filled in the summary phase and saves changes back to the existing plan record with regenerated configs.
- **Dashboard edit links** (closes #53): Added **Edit** link to each plan card on `/dashboard` and an **Edit plan** button on `/dashboard/[planId]` — the primary place users access their plans.

## What changed

### Compare panel
- `src/components/wizard/WizardComparePanel.tsx` — slide-over panel with option selectors and full comparison UI
- `src/components/wizard/WizardStepContent.tsx` — Compare button wired into each step header

### Edit saved plans
- `src/app/wizard/edit/[planId]/page.tsx` — server component that fetches and validates the plan, renders edit shell
- `src/components/wizard/WizardEditShell.tsx` — client wrapper with pre-loaded `WizardProvider`
- `src/components/wizard/WizardProvider.tsx` — accepts `initialSelections` and `planId` props
- `src/components/wizard/WizardSummary.tsx` — calls `updateWizardPlan` when `planId` is in context
- `src/app/wizard/actions.ts` — `updateWizardPlan` server action with rate limiting; both actions use shared `wizardSelectionsSchema`
- `src/app/wizard/success/page.tsx` — Edit plan button added; `config_data` cast replaced with Zod validation
- `src/lib/wizard/state.ts` — `goToStep` now transitions phase to `steps` from `summary` so Edit buttons in the summary table actually navigate

### Dashboard edit links
- `src/components/dashboard/PlanCard.tsx` — Edit link added to card footer
- `src/app/dashboard/[planId]/page.tsx` — Edit plan button added to plan header

## Test plan

- [ ] On `/dashboard`, each plan card shows an **Edit** link — clicking it opens the wizard pre-filled in summary phase
- [ ] On `/dashboard/[planId]`, the **Edit plan** button appears in the header and works the same way
- [ ] Editing a step from summary navigates to that step; saving updates the existing plan and regenerates configs
- [ ] On any wizard step, **Compare** opens the side panel; selecting two options shows full comparison results
- [ ] Closing the panel (X or Escape) leaves wizard selection state unchanged
- [ ] `/wizard/edit/invalid-uuid` → 404; another user's plan ID → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)